### PR TITLE
Fixing convergence issue by adding tiny amount of O2

### DIFF
--- a/demos/cpp/demo-investigate-gaseous-initialization.cpp
+++ b/demos/cpp/demo-investigate-gaseous-initialization.cpp
@@ -26,6 +26,7 @@ auto solve(ChemicalEditor& editor) -> void {
 	ChemicalSystem system(editor);
 
 	EquilibriumProblem problem(system);
+	problem.add("O2", 1, "umol");
 	problem.add("CO2(g)", 1, "mol");
 	problem.add("H2O(g)", 1, "mol");
 	problem.add("H2S(g)", 1, "mol");


### PR DESCRIPTION
The change in problem specification solves the convergence issue. This is indeed caused by round-off errors. So, adding 1e-6 moles of O2 corrects the bad numerical behavior. The new minimization algorithm implemented in Optima should be able to solve this problem without this minor addition of O2. I still have not had the time to couple new Optima library in Reaktoro. :disappointed: