### PR TITLE
Avoid conversion if units are the same

### DIFF
--- a/Reaktoro/Common/Units.cpp
+++ b/Reaktoro/Common/Units.cpp
@@ -643,6 +643,9 @@ inline void checkConvertibleUnits(const DerivedUnit& from, const DerivedUnit& to
 
 double convert(double value, const string& from, const string& to)
 {
+    if (from == to) {
+        return value;
+    }
     if(internal::temperatureUnitsMap.count(from) && internal::temperatureUnitsMap.count(to))
         return internal::convertTemperature(value, from, to);
     auto parsed_from = internal::parseUnit(from);


### PR DESCRIPTION
This will prevent the introduction of floating point errors

Multiplication by a factor of `1.0` would be ok, but the factor is a numeric construction, and may introduce precision noise in the conversion.